### PR TITLE
Deprecated index of fix

### DIFF
--- a/views/admin/javascripts/OmekaFootnotes.js
+++ b/views/admin/javascripts/OmekaFootnotes.js
@@ -1,8 +1,8 @@
-jQuery(document).ready(function() {
+jQuery(document).ready(function () {
   displayFootnotes();
 });
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function () {
   displayFootnotes();
 });
 
@@ -23,7 +23,7 @@ function displayFootnotes() {
       "addFootnoteButton | deleteFootnotesButton | updateFootnotesButton"
     ],
     setup: function (editor) {
-    editor.addButton('addFootnoteButton', {
+      editor.ui.registry.addButton('addFootnoteButton', {
         text: 'Add Footnote',
         onclick: function () {
           // Add the new footnote link
@@ -34,7 +34,7 @@ function displayFootnotes() {
           addNewFootnoteLink(editor, fnNextNum);
           var tinymceBody = getTinyMCEDOMObject();
           // Add the new footnote citation
-          if(getNumberOfFootnoteDivs(tinymceBody) == 0){
+          if (getNumberOfFootnoteDivs(tinymceBody) == 0) {
             addFootnoteDiv(tinymceBody);
           }
           addFootnoteCitation(tinymceBody, fnNextNum);
@@ -44,45 +44,45 @@ function displayFootnotes() {
           updateFootnotes();
         }
       });
-    editor.addButton('updateFootnotesButton', {
+      editor.ui.registry.addButton('updateFootnotesButton', {
         text: 'Update Footnotes',
         onclick: function () {
-            updateFootnotes();
+          updateFootnotes();
         }
       });
-    editor.addButton('deleteFootnotesButton', {
-          text: 'Delete Selected Footnotes',
-          onclick: function () {
-              updateFootnotes();
-              var tinymceBody = getTinyMCEDOMObject();
-              node = editor.selection.getNode();
-              parent = node.parentNode;
-              var selectedHTML = editor.selection.getContent({format : 'html'}).toString();
-              if(selectedHTML.length <= 1){
-                //if the highlighted text is the single number of the footnote, the outerHTML will let us access the whole node.
-                //Note: we can't just use the single number of innerHTML because then any time someone highlights a regular text number,
-                //  the footnote with that number will be deleted
-                selectedHTML = editor.selection.getNode().outerHTML.toString();
-              }
-              var idsFootnotesToDelete = getListOfFootnotesToDelete(selectedHTML);
-              var fnLinks = getFnLinks(tinymceBody);
-              var fnCitations = getFnCitations(tinymceBody);
-              for(j = 0; j < idsFootnotesToDelete.length; j++){
-                var fnLinkIDs = getFnLinkIDs(fnLinks);
-                var indexDel = fnLinkIDs.indexOf(idsFootnotesToDelete[j]);
-                fnLinkToDelete = fnLinks.item(indexDel);
-                fnLinkParent = fnLinkToDelete.parentNode;
-                fnLinkParent.removeChild(fnLinkToDelete);
-                if(fnCitations.length == 1){
-                  tinymceBody.removeChild(getExistingFootnoteDiv(tinymceBody));
-                } else {
-                  fnCitToDelete = fnCitations.item(indexDel);
-                  fnCitParent = fnCitToDelete.parentNode;
-                  fnCitParent.removeChild(fnCitToDelete);
-                }
-              }
-              updateFootnotes();
+      editor.ui.registry.addButton('deleteFootnotesButton', {
+        text: 'Delete Selected Footnotes',
+        onclick: function () {
+          updateFootnotes();
+          var tinymceBody = getTinyMCEDOMObject();
+          node = editor.selection.getNode();
+          parent = node.parentNode;
+          var selectedHTML = editor.selection.getContent({ format: 'html' }).toString();
+          if (selectedHTML.length <= 1) {
+            //if the highlighted text is the single number of the footnote, the outerHTML will let us access the whole node.
+            //Note: we can't just use the single number of innerHTML because then any time someone highlights a regular text number,
+            //  the footnote with that number will be deleted
+            selectedHTML = editor.selection.getNode().outerHTML.toString();
           }
+          var idsFootnotesToDelete = getListOfFootnotesToDelete(selectedHTML);
+          var fnLinks = getFnLinks(tinymceBody);
+          var fnCitations = getFnCitations(tinymceBody);
+          for (j = 0; j < idsFootnotesToDelete.length; j++) {
+            var fnLinkIDs = getFnLinkIDs(fnLinks);
+            var indexDel = fnLinkIDs.indexOf(idsFootnotesToDelete[j]);
+            fnLinkToDelete = fnLinks.item(indexDel);
+            fnLinkParent = fnLinkToDelete.parentNode;
+            fnLinkParent.removeChild(fnLinkToDelete);
+            if (fnCitations.length == 1) {
+              tinymceBody.removeChild(getExistingFootnoteDiv(tinymceBody));
+            } else {
+              fnCitToDelete = fnCitations.item(indexDel);
+              fnCitParent = fnCitToDelete.parentNode;
+              fnCitParent.removeChild(fnCitToDelete);
+            }
+          }
+          updateFootnotes();
+        }
       });
     },
   }
@@ -99,65 +99,65 @@ function displayFootnotes() {
   });
 }
 
-function getListOfFootnotesToDelete(selectedHTML){
+function getListOfFootnotesToDelete(selectedHTML) {
   var idsFootnotesToDelete = [];
-  numFootnoteLinks = selectedHTML.split('<a href=\"#fn:').length-1;
+  numFootnoteLinks = selectedHTML.split('<a href=\"#fn:').length - 1;
   remainingHTML = selectedHTML;
-  for(i = 0; i < numFootnoteLinks; i++){
+  for (i = 0; i < numFootnoteLinks; i++) {
     var idIndexStart = remainingHTML.indexOf("<a href=\"#fn:") + 13;
-    var idIndexEnd = remainingHTML.substring(idIndexStart, ).indexOf("\">") + idIndexStart;
+    var idIndexEnd = remainingHTML.substring(idIndexStart,).indexOf("\">") + idIndexStart;
     var id = parseInt(remainingHTML.substring(idIndexStart, idIndexEnd));
     idsFootnotesToDelete.push(id);
-    remainingHTML = remainingHTML.substring(idIndexEnd + 2, );
+    remainingHTML = remainingHTML.substring(idIndexEnd + 2,);
   }
   return idsFootnotesToDelete;
 }
 
-function updateFootnotes(){
+function updateFootnotes() {
   var bodies = getAllTinyMCETextBodies();
-  for(var i = 0; i < bodies.length; i++){
+  for (var i = 0; i < bodies.length; i++) {
     var currentBody = bodies[i];
     addFootnoteLinkClassToFootnoteLinks(currentBody);
     var numOfFns = getNumberOfExistingLinks(currentBody);
-    if(numOfFns > 0){
-        // Check formatting of footnote links to make sure they're OK
-        if(getNumberOfFootnoteDivs(currentBody) == 0){
-          addFootnoteDiv(currentBody);
-        } else if (getNumberOfFootnoteDivs(currentBody) > 1){
-          mergeFootnoteDivs(currentBody);
-        }
-        correctFootnoteLinkFormatting(currentBody);
-        var numOfFns = getNumberOfExistingLinks(currentBody);
-        correctFootnoteCitationFormatting(currentBody, numOfFns)
-        numOfFns = getNumberOfExistingLinks(currentBody);
-        correctFootnoteCitationsOrder(currentBody);
-        // correctFootnoteLinksOrder(currentBody);
-        alertUserOfExtraFootnotes(currentBody, numOfFns);
+    if (numOfFns > 0) {
+      // Check formatting of footnote links to make sure they're OK
+      if (getNumberOfFootnoteDivs(currentBody) == 0) {
+        addFootnoteDiv(currentBody);
+      } else if (getNumberOfFootnoteDivs(currentBody) > 1) {
+        mergeFootnoteDivs(currentBody);
+      }
+      correctFootnoteLinkFormatting(currentBody);
+      var numOfFns = getNumberOfExistingLinks(currentBody);
+      correctFootnoteCitationFormatting(currentBody, numOfFns)
+      numOfFns = getNumberOfExistingLinks(currentBody);
+      correctFootnoteCitationsOrder(currentBody);
+      // correctFootnoteLinksOrder(currentBody);
+      alertUserOfExtraFootnotes(currentBody, numOfFns);
     }
   }
   updateOLsAcrossAllTextEditorBoxes();
 }
 
-function updateOLsAcrossAllTextEditorBoxes(){
+function updateOLsAcrossAllTextEditorBoxes() {
   var bodies = getAllTinyMCETextBodies();
   var numPrevFns = 0;
   //For each tinymce-text-body:
-  for(var i = 0; i < bodies.length; i++){
+  for (var i = 0; i < bodies.length; i++) {
     var currentBody = bodies[i];
     // Let orderedList be the ordered list in the tinymce-body
     var orderedList = getOrderedList(currentBody);
-    if(orderedList!=null){
+    if (orderedList != null) {
       // Update orderedList.start to be (numPrevFns + 1).
       orderedList.start = numPrevFns + 1;
       // for each Links[i] of the body, assign it the ID: (i + numPrevFns)
       var links = getFnLinks(currentBody);
-      for(var j = 0; j < links.length; j++){
-          updateLinkID(links[j], j+numPrevFns+1);
+      for (var j = 0; j < links.length; j++) {
+        updateLinkID(links[j], j + numPrevFns + 1);
       }
       // for each citation[i] of the body, assign it the ID: i + numPrevFns
       var citations = getFnCitations(currentBody);
-      for(var k = 0; k < citations.length; k++){
-          updateCitationID(citations[k], k+numPrevFns+1);
+      for (var k = 0; k < citations.length; k++) {
+        updateCitationID(citations[k], k + numPrevFns + 1);
       }
       // Increment numPrevFns by the number of footnote citations in the tinymce-body
       numPrevFns = numPrevFns + getNumberOfExistingCitations(currentBody);
@@ -165,87 +165,87 @@ function updateOLsAcrossAllTextEditorBoxes(){
   }
 }
 
-function getAllTinyMCETextBodies(){
+function getAllTinyMCETextBodies() {
   var iFrames = document.getElementsByTagName("iframe");
   var textBodies = [];
   var j = 0;
-  for(var i = 0; i< iFrames.length; i++){
-    if(iFrames[i].id.indexOf("text_ifr") != -1){
-        var innerDoc = iFrames[i].contentDocument || iFrames[i].contentWindow.document;
-        textBodies[j] = innerDoc.getElementsByClassName("mce-content-body").item(0);
-        j++;
+  for (var i = 0; i < iFrames.length; i++) {
+    if (iFrames[i].id.indexOf("text_ifr") != -1) {
+      var innerDoc = iFrames[i].contentDocument || iFrames[i].contentWindow.document;
+      textBodies[j] = innerDoc.getElementsByClassName("mce-content-body").item(0);
+      j++;
     }
   }
   return textBodies;
 }
 
-function getTinyMCEDOMObject(){
+function getTinyMCEDOMObject() {
   var currentNode = tinymce.activeEditor.selection.getNode();
-  while(!(currentNode.className.trim() === "mce-content-body")){
+  while (!(currentNode.className.trim() === "mce-content-body")) {
     currentNode = currentNode.parentNode;
   }
   return currentNode;
 }
 
-function getOrderedList(tinymceBody){
+function getOrderedList(tinymceBody) {
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
-  if(footnoteDiv==null){
+  if (footnoteDiv == null) {
     return null;
   }
   var orderedList = footnoteDiv.getElementsByTagName('ol').item(0);
   return orderedList;
 }
 
-function addFootnoteLinkClassToFootnoteLinks(tinymceBody){
-    var i = 0;
-    var supElements = tinymceBody.getElementsByTagName("sup");
-    for(i = 0; i < supElements.length; i++){
-      var sup = supElements[i];
-      if(sup.id.includes('fnref')){
-        sup.className = "footnote link";
-      }
+function addFootnoteLinkClassToFootnoteLinks(tinymceBody) {
+  var i = 0;
+  var supElements = tinymceBody.getElementsByTagName("sup");
+  for (i = 0; i < supElements.length; i++) {
+    var sup = supElements[i];
+    if (sup.id.includes('fnref')) {
+      sup.className = "footnote link";
     }
+  }
 }
 
-function getNumberOfExistingLinks(tinymceBody){
+function getNumberOfExistingLinks(tinymceBody) {
   return tinymceBody.getElementsByClassName("footnote link").length;
 }
 
-function getNumberOfExistingCitations(tinymceBody){
+function getNumberOfExistingCitations(tinymceBody) {
   // return tinymceBody.getElementsByClassName("footnote").length;
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
-  if(footnoteDiv==null){
+  if (footnoteDiv == null) {
     return null;
   }
   var fnCitations = footnoteDiv.getElementsByTagName("li");
   return fnCitations.length;
 }
 
-function getFnNextNum(tinymceBody){
+function getFnNextNum(tinymceBody) {
   var allTinymceBodies = getAllTinyMCETextBodies();
   tinymceBodyIndex = allTinymceBodies.indexOf(tinymceBody);
   var numOfPreviousCits = 0;
-  for(var i = 0; i <= tinymceBodyIndex; i++){
+  for (var i = 0; i <= tinymceBodyIndex; i++) {
     numOfPreviousCits = numOfPreviousCits + getNumberOfExistingCitations(allTinymceBodies[i]);
   }
   var fnNextNum = numOfPreviousCits + 1;
   return fnNextNum;
 }
 
-function getFnLinks(tinymceBody){
+function getFnLinks(tinymceBody) {
   return tinymceBody.getElementsByClassName("footnote link");
 }
 
-function getFnCitations(tinymceBody){
+function getFnCitations(tinymceBody) {
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
-  if(footnoteDiv==null){
+  if (footnoteDiv == null) {
     return null;
   }
   var fnCitations = footnoteDiv.getElementsByTagName("li");
   return fnCitations;
 }
 
-function getLinkHTML(fnNextNum){
+function getLinkHTML(fnNextNum) {
   var str1 = '<sup class="footnote link" id="fnref:';
   var str2 = fnNextNum.toString();
   var str3 = '"><a href="#fn:';
@@ -257,11 +257,11 @@ function getLinkHTML(fnNextNum){
   return linkHTML;
 }
 
-function getExistingFootnoteDiv(tinymceBody){
+function getExistingFootnoteDiv(tinymceBody) {
   return tinymceBody.getElementsByClassName('footnotes').item(0);
 }
 
-function getNewListElement(fnNextNum){
+function getNewListElement(fnNextNum) {
   var list = document.createElement("li");
   var id = 'fn:';
   id = id.concat(fnNextNum.toString());
@@ -270,7 +270,7 @@ function getNewListElement(fnNextNum){
   return list;
 }
 
-function getNewLinkElement(fnNextNum){
+function getNewLinkElement(fnNextNum) {
   var link = document.createElement("a");
   var href = '#fnref:';
   href = href.concat(fnNextNum.toString())
@@ -281,14 +281,14 @@ function getNewLinkElement(fnNextNum){
   return link
 }
 
-function getNewParagraphElement(){
+function getNewParagraphElement() {
   var paragraph = document.createElement("p");
   var ptext = document.createTextNode("footnote citation here");
   paragraph.appendChild(ptext);
   return paragraph;
 }
 
-function getNewFootnoteListItem(fnNextNum){
+function getNewFootnoteListItem(fnNextNum) {
   var list = getNewListElement(fnNextNum);
   var link = getNewLinkElement(fnNextNum);
   var paragraph = getNewParagraphElement();
@@ -297,7 +297,7 @@ function getNewFootnoteListItem(fnNextNum){
   return list;
 }
 
-function getNewFootnoteDivElement(){
+function getNewFootnoteDivElement() {
   var footnoteDiv = document.createElement("div");
   footnoteDiv.classList.add("footnotes");
   var orderedList = document.createElement("ol");
@@ -305,23 +305,23 @@ function getNewFootnoteDivElement(){
   return footnoteDiv;
 }
 
-function getNumberOfFootnoteDivs(tinymceBody){
+function getNumberOfFootnoteDivs(tinymceBody) {
   return tinymceBody.getElementsByClassName("footnotes").length;
 }
 
 // Merge all the footnote divs by the ordered list of each footnote into the last footnote.
 // Then delete all but the last footnote div, which are now empty.
-function mergeFootnoteDivs(tinymceBody){
+function mergeFootnoteDivs(tinymceBody) {
   var foonoteDivs = tinymceBody.getElementsByClassName("footnotes");
   var i;
-    var indexOfLastFnDiv = foonoteDivs.length - 1;
-    for(i = 0; i < indexOfLastFnDiv; i++){
-      moveOlsFromOneFnDivToAnotherStackingUpwards(foonoteDivs.item(indexOfLastFnDiv), foonoteDivs.item(i));
-    }
-    deleteAllButOneFootnoteDiv(tinymceBody, foonoteDivs);
+  var indexOfLastFnDiv = foonoteDivs.length - 1;
+  for (i = 0; i < indexOfLastFnDiv; i++) {
+    moveOlsFromOneFnDivToAnotherStackingUpwards(foonoteDivs.item(indexOfLastFnDiv), foonoteDivs.item(i));
+  }
+  deleteAllButOneFootnoteDiv(tinymceBody, foonoteDivs);
 }
 
-function moveOlsFromOneFnDivToAnotherStackingUpwards(listReceiver, listGiver){
+function moveOlsFromOneFnDivToAnotherStackingUpwards(listReceiver, listGiver) {
   var child = listGiver.lastChild;
   var nextChild;
   while (child) {
@@ -331,23 +331,23 @@ function moveOlsFromOneFnDivToAnotherStackingUpwards(listReceiver, listGiver){
   }
 }
 
-function deleteAllButOneFootnoteDiv(tinymceBody, foonoteDivs){
+function deleteAllButOneFootnoteDiv(tinymceBody, foonoteDivs) {
   var i;
-  while(foonoteDivs.length > 1){
+  while (foonoteDivs.length > 1) {
     var childFnDivToRemove = foonoteDivs.item(0);
     tinymceBody.removeChild(childFnDivToRemove);
   }
 }
 
-function addNewFootnoteLink(editor, fnNextNum){
+function addNewFootnoteLink(editor, fnNextNum) {
   var linkHTML = getLinkHTML(fnNextNum);
   editor.insertContent(linkHTML);
 }
 
-function addFootnoteCitation(tinymceBody, fnNextNum){
+function addFootnoteCitation(tinymceBody, fnNextNum) {
   var newCitation = getNewFootnoteListItem(fnNextNum);
   var orderedList = getOrderedList(tinymceBody);
-  if(fnNextNum == 1){
+  if (fnNextNum == 1) {
     orderedList.appendChild(newCitation);
   } else {
     //put the new footnote in the proper place
@@ -356,27 +356,27 @@ function addFootnoteCitation(tinymceBody, fnNextNum){
     orderedList.insertBefore(newCitation, nextSibling)
     //update unlinked citations whose ID is larger than fnNextNum (the largest footnote link ID.
     //Since it is the largest there are no links connected to any of these citations).
-    for(var i = fnNextNum; i < fnCitations.length; i++){
-        var citBelowNewCit = fnCitations.item(i);
-        id = getFnCitationID(citBelowNewCit);
-        if (id >= fnNextNum){
-          updateCitationID(citBelowNewCit, id+1)
-        }
+    for (var i = fnNextNum; i < fnCitations.length; i++) {
+      var citBelowNewCit = fnCitations.item(i);
+      id = getFnCitationID(citBelowNewCit);
+      if (id >= fnNextNum) {
+        updateCitationID(citBelowNewCit, id + 1)
+      }
     }
   }
 }
 
-function addFootnoteDiv(tinymceBody){
+function addFootnoteDiv(tinymceBody) {
   var footnoteDiv = getNewFootnoteDivElement();
   tinymceBody.appendChild(footnoteDiv);
 }
 
-function getCurrentLinkIDs(tinymceBody){
+function getCurrentLinkIDs(tinymceBody) {
   var fnLinks = getFnLinks(tinymceBody);
   var assignedNums = [];
   for (i = 1; i < fnLinks.length + 1; i++) {
     var fnLink = fnLinks.item(i - 1);
-    assignedNums.push(fnLink.id.substring(6, ));
+    assignedNums.push(fnLink.id.substring(6,));
   }
   return assignedNums;
 }
@@ -394,24 +394,24 @@ function getCurrentLinkIDs(tinymceBody){
 //   }
 // }
 
-function correctFootnoteCitationsOrder(tinymceBody){
+function correctFootnoteCitationsOrder(tinymceBody) {
   var currentLinkIDs = getCurrentLinkIDs(tinymceBody);
   newSortFootnoteCitationsBasedOnLinkIDs(tinymceBody, currentLinkIDs);
   assignLinkIDsInIncreasingOrder(tinymceBody);
   assignFootnoteIDsInIncreasingOrder(tinymceBody);
 }
 
-function newSortFootnoteCitationsBasedOnLinkIDs(tinymceBody, linkIDs){
+function newSortFootnoteCitationsBasedOnLinkIDs(tinymceBody, linkIDs) {
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
   var fnCitations = getFnCitations(tinymceBody);
   var originalOL = getOrderedList(tinymceBody);
   var citationIDs = getFnCitationIDs(fnCitations);
   var fnCitationIDMap = getCitationIDMap(fnCitations, citationIDs);
   var newOL = originalOL.cloneNode(false); //an empty clone; has no children
-  for(var i = 0; i < linkIDs.length; i++){
+  for (var i = 0; i < linkIDs.length; i++) {
     linkID = linkIDs[i];
     //If (ID in CitationIDs), NewFootnoteList.append(CitationsByID[ID])
-    if(linkIDInCitationIDs(citationIDs, linkID)){
+    if (linkIDInCitationIDs(citationIDs, linkID)) {
       fnCitClone = cloneCitationByID(fnCitationIDMap, linkID);
       newOL.appendChild(fnCitClone);
     }
@@ -422,9 +422,9 @@ function newSortFootnoteCitationsBasedOnLinkIDs(tinymceBody, linkIDs){
     }
   }
   //For each citID in CitationIDs not in LinkIDs, NewFootnoteList.append(citations[citID])
-  for(var i = 0; i < citationIDs.length; i++){
+  for (var i = 0; i < citationIDs.length; i++) {
     citID = citationIDs[i];
-    if(citIDinLinkIDs(linkIDs, citID) == false){
+    if (citIDinLinkIDs(linkIDs, citID) == false) {
       fnCitClone = cloneCitationByID(fnCitationIDMap, citID);
       newOL.appendChild(fnCitClone);
     }
@@ -433,56 +433,56 @@ function newSortFootnoteCitationsBasedOnLinkIDs(tinymceBody, linkIDs){
   footnoteDiv.appendChild(newOL);
 }
 
-function linkIDInCitationIDs(citationIDs, linkID){
-  if(citationIDs.indexOf(linkID) == -1){
+function linkIDInCitationIDs(citationIDs, linkID) {
+  if (citationIDs.indexOf(linkID) == -1) {
     return false;
   } else {
     return true;
   }
 }
 
-function citIDinLinkIDs(linkIDs, citID){
-  if(linkIDs.indexOf(citID) == -1){
+function citIDinLinkIDs(linkIDs, citID) {
+  if (linkIDs.indexOf(citID) == -1) {
     return false;
   } else {
     return true;
   }
 }
 
-function cloneCitationByID(fnCitationIDMap, id){
+function cloneCitationByID(fnCitationIDMap, id) {
   var cloneCitation = fnCitationIDMap[id].cloneNode(true);
   return cloneCitation;
 }
 
-function getCitationIDMap(fnCitations){
+function getCitationIDMap(fnCitations) {
   var citationIDMap = {};
-  for(i = 0; i < fnCitations.length; i++){
+  for (i = 0; i < fnCitations.length; i++) {
     cit = fnCitations[i];
-    id = cit.id.substring(3, );
+    id = cit.id.substring(3,);
     citationIDMap[id] = cit;
   }
   return citationIDMap;
 }
 
-function sortLinkIDS(currentLinkIDs){
+function sortLinkIDS(currentLinkIDs) {
   sortedLinkIDs = []
-  for(x = 0; x < currentLinkIDs.length; x++){
+  for (x = 0; x < currentLinkIDs.length; x++) {
     sortedLinkIDs.push(currentLinkIDs[x]);
   }
   sortedLinkIDs = sortedLinkIDs.sort();
   return sortedLinkIDs;
 }
 
-function getFnCitationIDs(fnCitations){
+function getFnCitationIDs(fnCitations) {
   var fnCitationsIDs = [];
   for (i = 0; i < fnCitations.length; i++) {
     var fnCitation = fnCitations.item(i);
-    fnCitationsIDs.push(fnCitation.id.substring(3, ));
+    fnCitationsIDs.push(fnCitation.id.substring(3,));
   }
   return fnCitationsIDs;
 }
 
-function updateLinkID(fnLink, newID){
+function updateLinkID(fnLink, newID) {
   fnLink.id = "fnref:".concat(newID);
   var hrefLink = fnLink.getElementsByTagName("a").item(0);
   hrefLink.setAttribute("href", "#fn:".concat(newID));
@@ -490,58 +490,58 @@ function updateLinkID(fnLink, newID){
   hrefLink.textContent = newID.toString();
 }
 
-function updateCitationID(fnCitation, newID){
+function updateCitationID(fnCitation, newID) {
   newID = newID.toString();
   fnCitation.id = "fn:".concat(newID);
   var linkNodes = fnCitation.getElementsByTagName("a");
-  for(var i = 0; i < linkNodes.length; i++){
+  for (var i = 0; i < linkNodes.length; i++) {
     var linkChild = linkNodes[i];
-    if(linkChild.getAttribute("href").includes("#fnref:")){
+    if (linkChild.getAttribute("href").includes("#fnref:")) {
       linkChild.setAttribute("href", "#fnref:".concat(newID));
       linkChild.setAttribute("data-mce-href", "#fnref:".concat(newID));
     }
   }
 }
 
-function getFnCitationID(fnCitation){
-  return parseInt(fnCitation.id.substring(3, ));
+function getFnCitationID(fnCitation) {
+  return parseInt(fnCitation.id.substring(3,));
 }
 
-function getFnLinkID(fnLink){
-  return parseInt(fnLink.id.substring(6, ));
+function getFnLinkID(fnLink) {
+  return parseInt(fnLink.id.substring(6,));
 }
 
-function getFnLinkIDs(fnLinks){
+function getFnLinkIDs(fnLinks) {
   var linkIDs = [];
-  for(var i = 0; i<fnLinks.length; i++){
+  for (var i = 0; i < fnLinks.length; i++) {
     linkIDs[i] = getFnLinkID(fnLinks[i])
   }
   return linkIDs;
 }
 
-function assignLinkIDsInIncreasingOrder(tinymceBody){
+function assignLinkIDsInIncreasingOrder(tinymceBody) {
   fnLinks = getFnLinks(tinymceBody);
   var i;
   for (i = 1; i <= fnLinks.length; i++) {
-      var fnLink = fnLinks.item(i-1);
-      updateLinkID(fnLink, i);
+    var fnLink = fnLinks.item(i - 1);
+    updateLinkID(fnLink, i);
   }
 }
 
-function assignFootnoteIDsInIncreasingOrder(tinymceBody){
+function assignFootnoteIDsInIncreasingOrder(tinymceBody) {
   var fnCitations = getFnCitations(tinymceBody);
   for (i = 1; i <= fnCitations.length; i++) {
-      var fnCitation = fnCitations.item(i-1);
-      updateCitationID(fnCitation, i);
+    var fnCitation = fnCitations.item(i - 1);
+    updateCitationID(fnCitation, i);
   }
 }
 
-function correctFootnoteLinkFormatting(tinymceBody){
+function correctFootnoteLinkFormatting(tinymceBody) {
   var fnLinks = getFnLinks(tinymceBody);
   for (i = 1; i < fnLinks.length + 1; i++) {
     var fnLink = fnLinks.item(i - 1);
     // If the fnLink is just superscript text
-    if(isNoLongerALink(fnLink)){
+    if (isNoLongerALink(fnLink)) {
       removeBadLink(fnLink);
       var fnLinks = getFnLinks(tinymceBody);
       i = 1;
@@ -549,7 +549,7 @@ function correctFootnoteLinkFormatting(tinymceBody){
   }
   for (i = 1; i < fnLinks.length + 1; i++) {
     var fnLink = fnLinks.item(i - 1);
-    if(hasChildFootnoteLink(fnLink)){
+    if (hasChildFootnoteLink(fnLink)) {
       moveChildLinksOutOfParents(tinymceBody, fnLink, fnLinks, i);
       var fnLinks = getFnLinks(tinymceBody);
       i = 1;
@@ -557,41 +557,41 @@ function correctFootnoteLinkFormatting(tinymceBody){
   }
 }
 
-function isNoLongerALink(fnLink){
+function isNoLongerALink(fnLink) {
   var hrefLinks = fnLink.getElementsByTagName("a");
-  if(hrefLinks.length > 0){
+  if (hrefLinks.length > 0) {
     return false;
   }
   return true;
 }
 
-function removeBadLink(fnLink){
+function removeBadLink(fnLink) {
   fnLink.textContent = "";
   fnLink.parentNode.removeChild(fnLink);
 }
 
-function hasChildFootnoteLink(fnLink){
+function hasChildFootnoteLink(fnLink) {
   var childFootnoteLinks = fnLink.getElementsByClassName("footnote link");
-  if(childFootnoteLinks.length > 0){
+  if (childFootnoteLinks.length > 0) {
     return true;
   }
   return false;
 }
 
-function getNextLink(fnLinks, i){
-  if(i < fnLinks.length + 1){
+function getNextLink(fnLinks, i) {
+  if (i < fnLinks.length + 1) {
     return fnLinks.item(i + 1);
   }
   return null;
 }
 
-function moveChildLinksOutOfParents(tinymceBody, fnLink, fnLinks, linkIndex){
+function moveChildLinksOutOfParents(tinymceBody, fnLink, fnLinks, linkIndex) {
   var childFootnoteLinks = fnLink.getElementsByClassName("footnote link");
   var nextLink = getNextLink(fnLinks, linkIndex);
   var parentNode = fnLink.parentNode;
   var textnode = document.createTextNode(childFootnoteLinks.length.toString());
   var k;
-  for(k = 0; k < childFootnoteLinks.length + 1; k++){
+  for (k = 0; k < childFootnoteLinks.length + 1; k++) {
     var childLink = childFootnoteLinks.item(k);
     var period = childLink.nextSibling;
     parentNode.insertBefore(childLink, fnLink);
@@ -599,7 +599,7 @@ function moveChildLinksOutOfParents(tinymceBody, fnLink, fnLinks, linkIndex){
   }
 }
 
-function correctFootnoteCitationFormatting(tinymceBody, numOfFns){
+function correctFootnoteCitationFormatting(tinymceBody, numOfFns) {
   replaceInnerFootnoteDivIfLost(tinymceBody);
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
   fixMultipleOlIfNeeded(footnoteDiv);
@@ -618,13 +618,13 @@ function correctFootnoteCitationFormatting(tinymceBody, numOfFns){
     //for each citation look at the link nodes.
     // We make sure that there is exactly one #fnref link node by deleting all of them and readding them
     // This allows there to be other links that will not get deleted as we make these checks
-    if(linkNodes.length > 0){
-      for(k = linkNodes.length - 1; k >= 0; k = k - 1){
+    if (linkNodes.length > 0) {
+      for (k = linkNodes.length - 1; k >= 0; k = k - 1) {
         var linkChild = linkNodes.item(k);
-        if(linkChild.getAttribute("href").includes("#fnref:")){
+        if (linkChild.getAttribute("href").includes("#fnref:")) {
           //take the non arrow textContent of the link and save it as a textnode
           var innerLinkText = linkChild.textContent;
-          innerLinkText = innerLinkText.replace('↩','');
+          innerLinkText = innerLinkText.replace('↩', '');
           var linkChildTextNode = document.createTextNode(innerLinkText);
           paragraphChild.insertBefore(linkChildTextNode, linkChild);
           paragraphChild.removeChild(linkChild);
@@ -637,7 +637,7 @@ function correctFootnoteCitationFormatting(tinymceBody, numOfFns){
     //remove invisible string
     citationText = citationText.replace(String.fromCharCode(65279), "");
     //&#65279 is the Unicode Character 'ZERO WIDTH NO-BREAK SPACE'
-    if(citationText == "" || citationText.length == 0){
+    if (citationText == "" || citationText.length == 0) {
       paragraphChild.textContent = "footnote citation here";
     }
     var newLinkNode = getNewLinkElement(i + 1);
@@ -648,33 +648,33 @@ function correctFootnoteCitationFormatting(tinymceBody, numOfFns){
   createCitationsToMatchNumOfLinks(fnCitations, footnoteDiv, numOfFns);
 }
 
-function replaceInnerFootnoteDivIfLost(tinymceBody){
+function replaceInnerFootnoteDivIfLost(tinymceBody) {
   var footnoteDiv = getExistingFootnoteDiv(tinymceBody);
-  if(footnoteDiv.childElementCount == 0){
+  if (footnoteDiv.childElementCount == 0) {
     tinymceBody.replaceChild(getNewFootnoteDivElement(), footnoteDiv);
   }
 }
 
-function fixMultipleOlIfNeeded(footnoteDiv){
+function fixMultipleOlIfNeeded(footnoteDiv) {
   var orderedLists = footnoteDiv.getElementsByTagName("ol");
-  if(orderedLists.length == 0){
+  if (orderedLists.length == 0) {
     var orderedList = document.createElement("ol");
     footnoteDiv.appendChild(orderedList);
-  } else if(orderedLists.length > 1){
+  } else if (orderedLists.length > 1) {
     moveListItemsToTheLastOrderedList(orderedLists);
     deleteAllButOneOrderedList(footnoteDiv, orderedLists);
   }
 }
 
-function moveListItemsToTheLastOrderedList(orderedLists){
+function moveListItemsToTheLastOrderedList(orderedLists) {
   var i;
   var indexOfLastOl = orderedLists.length - 1;
-  for(i = 0; i < indexOfLastOl; i++){
+  for (i = 0; i < indexOfLastOl; i++) {
     moveListItemsFromOneListToAnotherStackingUpwards(orderedLists.item(indexOfLastOl), orderedLists.item(i));
   }
 }
 
-function moveListItemsFromOneListToAnotherStackingUpwards(listReceiver, listGiver){
+function moveListItemsFromOneListToAnotherStackingUpwards(listReceiver, listGiver) {
   var child = listGiver.lastChild;
   var nextChild;
   while (child) {
@@ -684,24 +684,24 @@ function moveListItemsFromOneListToAnotherStackingUpwards(listReceiver, listGive
   }
 }
 
-function deleteAllButOneOrderedList(footnoteDiv, orderedLists){
+function deleteAllButOneOrderedList(footnoteDiv, orderedLists) {
   var i;
-  while(orderedLists.length > 1){
+  while (orderedLists.length > 1) {
     var childOlToRemove = orderedLists.item(0);
     footnoteDiv.removeChild(childOlToRemove);
   }
 }
 
-function ensureParagraphElementInCitation(fnCitation){
+function ensureParagraphElementInCitation(fnCitation) {
   // If the paragraph element was deleted, we add a new one
   var paragraphElements = fnCitation.getElementsByTagName("p");
-  if(paragraphElements.length > 1){
+  if (paragraphElements.length > 1) {
     var mergedText = "";
-    for(p = 0; p < paragraphElements.length; p++){
+    for (p = 0; p < paragraphElements.length; p++) {
       var currParagraph = paragraphElements.item(p);
       mergedText = mergedText.concat(currParagraph.textContent);
     }
-    for(p = paragraphElements.length; p > 0; p--){
+    for (p = paragraphElements.length; p > 0; p--) {
       var currParagraph = paragraphElements.item(p);
       fnCitation.removeChild(currParagraph);
     }
@@ -709,20 +709,20 @@ function ensureParagraphElementInCitation(fnCitation){
   }
   else {
     var paragraph = paragraphElements.item(0);
-    if(paragraph == null){
+    if (paragraph == null) {
       addNewParagraphElementToFootnoteCitation(fnCitation);
     }
     // If there is no text and no link, we add both
-    else if (paragraph.textContent == ""){
+    else if (paragraph.textContent == "") {
       paragraph.textContent = "footnote citation here";
       removeBreaksWithinCitation(fnCitation);
     }
   }
 }
 
-function addNewParagraphElementToFootnoteCitation(fnCitation){
+function addNewParagraphElementToFootnoteCitation(fnCitation) {
   var newParagraph = getNewParagraphElement();
-  if(fnCitation.textContent != ""){
+  if (fnCitation.textContent != "") {
     moveTextContentToNewParagraph(fnCitation, newParagraph);
     moveLinkWithinParagraphIfExists(fnCitation, newParagraph);
   }
@@ -730,14 +730,14 @@ function addNewParagraphElementToFootnoteCitation(fnCitation){
   removeBreaksWithinCitation(fnCitation);
 }
 
-function moveTextContentToNewParagraph(fnCitation, newParagraph){
+function moveTextContentToNewParagraph(fnCitation, newParagraph) {
   var citationText = fnCitation.textContent.toString();
   citationText = citationText.replace("↩", "");
   newParagraph.textContent = citationText;
   deleteTextNodeContentOfCitation(fnCitation);
 }
 
-function deleteTextNodeContentOfCitation(fnCitation){
+function deleteTextNodeContentOfCitation(fnCitation) {
   var child = fnCitation.firstChild;
   var nextChild;
   while (child) {
@@ -749,26 +749,26 @@ function deleteTextNodeContentOfCitation(fnCitation){
   }
 }
 
-function moveLinkWithinParagraphIfExists(fnCitation, newParagraph){
+function moveLinkWithinParagraphIfExists(fnCitation, newParagraph) {
   var link = fnCitation.getElementsByTagName("a").item(0);
-  if(link != null){
+  if (link != null) {
     newParagraph.appendChild(link);
   }
 }
 
-function removeBreaksWithinCitation(fnCitation){
+function removeBreaksWithinCitation(fnCitation) {
   var breaks = fnCitation.getElementsByTagName("br");
   var i;
-  for(i = breaks.length - 1; i >= 0; i--){
+  for (i = breaks.length - 1; i >= 0; i--) {
     fnCitation.removeChild(breaks.item(i));
   }
 }
 
-function createCitationsToMatchNumOfLinks(fnCitations, footnoteDiv, numOfFns){
+function createCitationsToMatchNumOfLinks(fnCitations, footnoteDiv, numOfFns) {
   // if there more links than footnotes create new ones
-  if (numOfFns > fnCitations.length){
+  if (numOfFns > fnCitations.length) {
     var n;
-    for(n = fnCitations.length + 1; n <= numOfFns; n++){
+    for (n = fnCitations.length + 1; n <= numOfFns; n++) {
       var newCitation = getNewFootnoteListItem(n);
       var fnNewCitationParagraph = newCitation.getElementsByTagName("p").item(0);
       var footnoteList = footnoteDiv.getElementsByTagName("ol").item(0);
@@ -777,17 +777,17 @@ function createCitationsToMatchNumOfLinks(fnCitations, footnoteDiv, numOfFns){
   }
 }
 
-function alertUserOfExtraFootnotes(tinymceBody, numOfFns){
+function alertUserOfExtraFootnotes(tinymceBody, numOfFns) {
   var fnCitations = getFnCitations(tinymceBody);
   var i;
   for (i = 0; i < fnCitations.length; i++) {
     var fnCitation = fnCitations.item(i);
     var n;
-    for(n = 0; n < fnCitation.childNodes.length; n++){
+    for (n = 0; n < fnCitation.childNodes.length; n++) {
       var fnCitationChild = fnCitation.childNodes[n];
       //If the node is an element node, the nodeType property will return 1.
-      if(fnCitationChild.nodeType == 1){
-        if(i + 1 > numOfFns){
+      if (fnCitationChild.nodeType == 1) {
+        if (i + 1 > numOfFns) {
           // change color to red
           fnCitationChild.style.color = "#ff0000";
         } else {

--- a/views/admin/javascripts/OmekaFootnotes.js
+++ b/views/admin/javascripts/OmekaFootnotes.js
@@ -23,7 +23,7 @@ function displayFootnotes() {
       "addFootnoteButton | deleteFootnotesButton | updateFootnotesButton"
     ],
     setup: function (editor) {
-      editor.ui.registry.addButton('addFootnoteButton', {
+      editor.addButton('addFootnoteButton', {
         text: 'Add Footnote',
         onclick: function () {
           // Add the new footnote link
@@ -44,13 +44,13 @@ function displayFootnotes() {
           updateFootnotes();
         }
       });
-      editor.ui.registry.addButton('updateFootnotesButton', {
+      editor.addButton('updateFootnotesButton', {
         text: 'Update Footnotes',
         onclick: function () {
           updateFootnotes();
         }
       });
-      editor.ui.registry.addButton('deleteFootnotesButton', {
+      editor.addButton('deleteFootnotesButton', {
         text: 'Delete Selected Footnotes',
         onclick: function () {
           updateFootnotes();


### PR DESCRIPTION
- Reverted `editor.ui.registry.addButton` to `editor.addButton` because the current TinyMCE version is 4 and the new syntax is for version 5+.
- Updated `.load(function() {})` to `.on('load',function() {})` for jQuery version 3+.

Closes #9.