### PR TITLE
Fix tinymce error for new version of Omeka 3.2 and TinyMCE 5+

### DIFF
--- a/plugin.ini
+++ b/plugin.ini
@@ -1,8 +1,8 @@
 [info]
 name = "Omeka Footnotes JS"
-author = "Austin Mason, Alec Wang, Shiyue Zhang, Chris Padilla, Alvin Bierley"
-version = "1.1"
-omeka_minimum_version="2.6"
-omeka_target_version="3.0.1"
+author = "Austin Mason, Alec Wang, Shiyue Zhang, Chris Padilla, Alvin Bierley, Mai Tran"
+version = "1.2"
+omeka_minimum_version="3.2"
+omeka_target_version="3.2"
 description = "A plugin to add bigfoot.js footnote functionality to the WYSIWYG on simple or exhibit pages."
 required_plugins = "ExhibitBuilder,SimplePages"

--- a/views/admin/javascripts/OmekaFootnotes.js
+++ b/views/admin/javascripts/OmekaFootnotes.js
@@ -25,7 +25,7 @@ function displayFootnotes() {
     setup: function (editor) {
       editor.ui.registry.addButton('addFootnoteButton', {
         text: 'Add Footnote',
-        onclick: function () {
+        onAction: function () {
           // Add the new footnote link
           var tinymceBody = getTinyMCEDOMObject();
           addFootnoteLinkClassToFootnoteLinks(tinymceBody);
@@ -46,13 +46,13 @@ function displayFootnotes() {
       });
       editor.ui.registry.addButton('updateFootnotesButton', {
         text: 'Update Footnotes',
-        onclick: function () {
+        onAction: function () {
           updateFootnotes();
         }
       });
       editor.ui.registry.addButton('deleteFootnotesButton', {
         text: 'Delete Selected Footnotes',
-        onclick: function () {
+        onAction: function () {
           updateFootnotes();
           var tinymceBody = getTinyMCEDOMObject();
           node = editor.selection.getNode();


### PR DESCRIPTION
* Allow new tinymce syntax to work for addButton and onAction
   * tested on Omeka 3.2

Closes #10 